### PR TITLE
Updated vfc_tests_config.json with SM4

### DIFF
--- a/vfc_tests_config.json
+++ b/vfc_tests_config.json
@@ -8,47 +8,7 @@
                 {
                     "name": "libinterflop_mca.so",
                     "repetitions": 50
-                }
-            ]
-        },
-
-        {
-            "executable": "bin/vfc_test_h5",
-            "parameters" : "sm1 vfc_ci_cycles.txt",
-            "vfc_backends": [
-                {
-                    "name": "libinterflop_mca.so",
-                    "repetitions": 50
-                }
-            ]
-        },
-
-        {
-            "executable": "bin/vfc_test_h5",
-            "parameters" : "sm2 vfc_ci_cycles.txt",
-            "vfc_backends": [
-                {
-                    "name": "libinterflop_mca.so",
-                    "repetitions": 50
-                }
-            ]
-        },
-
-        {
-            "executable": "bin/vfc_test_h5",
-            "parameters" : "sm3 vfc_ci_cycles.txt",
-            "vfc_backends": [
-                {
-                    "name": "libinterflop_mca.so",
-                    "repetitions": 50
-                }
-            ]
-        },
-
-        {
-            "executable": "bin/vfc_test_h5",
-            "parameters" : "maponia3 vfc_ci_cycles.txt",
-            "vfc_backends": [
+                },
                 {
                     "name": "libinterflop_mca.so --mode=rr",
                     "repetitions": 50
@@ -61,6 +21,10 @@
             "parameters" : "sm1 vfc_ci_cycles.txt",
             "vfc_backends": [
                 {
+                    "name": "libinterflop_mca.so",
+                    "repetitions": 50
+                },
+                {
                     "name": "libinterflop_mca.so --mode=rr",
                     "repetitions": 50
                 }
@@ -72,6 +36,10 @@
             "parameters" : "sm2 vfc_ci_cycles.txt",
             "vfc_backends": [
                 {
+                    "name": "libinterflop_mca.so",
+                    "repetitions": 50
+                },
+                {
                     "name": "libinterflop_mca.so --mode=rr",
                     "repetitions": 50
                 }
@@ -82,6 +50,25 @@
             "executable": "bin/vfc_test_h5",
             "parameters" : "sm3 vfc_ci_cycles.txt",
             "vfc_backends": [
+                {
+                    "name": "libinterflop_mca.so",
+                    "repetitions": 50
+                },
+                {
+                    "name": "libinterflop_mca.so --mode=rr",
+                    "repetitions": 50
+                }
+            ]
+        },
+
+        {
+            "executable": "bin/vfc_test_h5",
+            "parameters" : "sm4 vfc_ci_cycles.txt",
+            "vfc_backends": [
+                {
+                    "name": "libinterflop_mca.so",
+                    "repetitions": 50
+                },
                 {
                     "name": "libinterflop_mca.so --mode=rr",
                     "repetitions": 50


### PR DESCRIPTION
Because the algorithm to use is passed as a parameter to vfc_tests_h5,
it was necessary to update the tests configuration to add a new
execution.