### PR TITLE
Solved bug in Woodbury and SM/WB mix kernels

### DIFF
--- a/include/SMWB.hpp
+++ b/include/SMWB.hpp
@@ -3,15 +3,15 @@
 void SMWB1(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
          double *Updates, unsigned int *Updates_index);
 
-// Sherman-Morrison-Woodbury kernel 2
-// WB2, WB3, SM3 mixing scheme
-void SMWB2(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
-         double *Updates, unsigned int *Updates_index);
+// // Sherman-Morrison-Woodbury kernel 2
+// // WB2, WB3, SM3 mixing scheme
+// void SMWB2(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
+//          double *Updates, unsigned int *Updates_index);
 
-// Sherman-Morrison-Woodbury kernel 3
-// WB2, WB3, SM4 mixing scheme
-void SMWB3(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
-         double *Updates, unsigned int *Updates_index);
+// // Sherman-Morrison-Woodbury kernel 3
+// // WB2, WB3, SM4 mixing scheme
+// void SMWB3(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
+//          double *Updates, unsigned int *Updates_index);
 
 // Sherman-Morrison-Woodbury kernel 4
 // WB2, SM2 mixing scheme

--- a/include/SM_Standard.hpp
+++ b/include/SM_Standard.hpp
@@ -7,6 +7,9 @@ void SM1(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
 void SM2(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
          double *Updates, unsigned int *Updates_index);
 
+void SM2star(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
+         double *Updates, unsigned int *Updates_index, double *later_updates, unsigned int* later_index, unsigned int *later);
+
 // Sherman Morrison, leaving zero denominators for later
 void SM3(double *Slater_inv, unsigned int Dim, unsigned int N_updates,
          double *Updates, unsigned int *Updates_index);

--- a/src/SMWB.cpp
+++ b/src/SMWB.cpp
@@ -3,6 +3,9 @@
 #include "Woodbury.hpp"
 #include "Helpers.hpp"
 
+// #define DEBUG1
+// #define DEBUG2
+
 // Sherman-Morrison-Woodbury kernel 1
 // WB2, WB3, SM2 mixing scheme
 void SMWB1(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double *Updates, unsigned int *Updates_index) {
@@ -19,6 +22,9 @@ void SMWB1(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double 
   unsigned int length_1block = 1 * Dim;
 
   // Apply first 3*n_of_3blocks updates in n_of_3blocks blocks of 3 updates with Woodbury 3x3 kernel
+  double later_updates[Dim * N_updates];
+  unsigned int later_index[N_updates];
+  unsigned int later = 0;
   if (n_of_3blocks > 0) {
     for (unsigned int i = 0; i < n_of_3blocks; i++) {
       double *Updates_3block = &Updates[i * length_3block];
@@ -26,12 +32,14 @@ void SMWB1(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double 
       bool ok;
       ok = WB3(Slater_inv, Dim, Updates_3block, Updates_index_3block);
       if (!ok) { // Send the entire block to SM2
-#ifdef DEBUG2      
+        #ifdef DEBUG2      
         std::cerr << "Woodbury 3x3 kernel failed! Sending block to SM2" << std::endl;
         showMatrix2(Updates_3block, 3, Dim, "Updates_3block");
         showMatrix2(Updates_index_3block, 1, 3, "Updates_index_3block");
-#endif
-        SM2(Slater_inv, Dim, 3, Updates_3block, Updates_index_3block);
+        #endif
+        unsigned int l = 0;
+        SM2star(Slater_inv, Dim, 3, Updates_3block, Updates_index_3block, later_updates + (Dim * later), later_index + later, &l);
+        later = later + l;
       }
     }
   }
@@ -42,125 +50,132 @@ void SMWB1(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double 
     bool ok;
     ok = WB2(Slater_inv, Dim, Updates_2block, Updates_index_2block);
     if (!ok) { // Send the entire block to SM2
-#ifdef DEBUG2    
+      #ifdef DEBUG2    
       std::cerr << "Woodbury 2x2 kernel failed! Sending block to SM2" << std::endl;
-#endif      
-      SM2(Slater_inv, Dim, 2, Updates_2block, Updates_index_2block);
+      #endif      
+      unsigned int l = 0;
+      SM2star(Slater_inv, Dim, 2, Updates_2block, Updates_index_2block, later_updates+(Dim * later), later_index + later, &l);
+      later = later + l;
     }
   } else if (remainder == 1) { // Apply last remaining update with SM2
     double *Updates_1block = &Updates[n_of_3blocks * length_3block];
     unsigned int *Updates_index_1block = &Updates_index[3 * n_of_3blocks];
-    SM2(Slater_inv, Dim, 1, Updates_1block, Updates_index_1block);
-  } else { // remainder == 0
-    // Nothing left to do.
+    unsigned int l = 0;
+    SM2star(Slater_inv, Dim, 1, Updates_1block, Updates_index_1block, later_updates+(Dim * later), later_index + later, &l);
+    later = later + l;
   }
+
+  if (later > 0) {
+    SM2(Slater_inv, Dim, later, later_updates, later_index);
+  }
+
 }
 
-// Sherman-Morrison-Woodbury kernel 2
-// WB2, WB3, SM3 mixing scheme
-void SMWB2(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double *Updates, unsigned int *Updates_index) {
-#ifdef DEBUG2
-  std::cerr << "Called Sherman-Morrison-Woodbury kernel 1 with " << N_updates << " updates" << std::endl;
-#endif
+// // Sherman-Morrison-Woodbury kernel 2
+// // WB2, WB3, SM3 mixing scheme
+// void SMWB2(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double *Updates, unsigned int *Updates_index) {
+// #ifdef DEBUG2
+//   std::cerr << "Called Sherman-Morrison-Woodbury kernel 1 with " << N_updates << " updates" << std::endl;
+// #endif
 
-  unsigned int n_of_3blocks = N_updates / 3;
-  unsigned int remainder = N_updates % 3;
-  unsigned int length_3block = 3 * Dim;
-  unsigned int length_2block = 2 * Dim;
-  unsigned int length_1block = 1 * Dim;
+//   unsigned int n_of_3blocks = N_updates / 3;
+//   unsigned int remainder = N_updates % 3;
+//   unsigned int length_3block = 3 * Dim;
+//   unsigned int length_2block = 2 * Dim;
+//   unsigned int length_1block = 1 * Dim;
 
-#ifdef DEBUG2
-  showMatrix2(Updates_index, 1, N_updates, "Updates_index");
-  showMatrix2(Updates, N_updates, Dim, "Updates");
-#endif
+// #ifdef DEBUG2
+//   showMatrix2(Updates_index, 1, N_updates, "Updates_index");
+//   showMatrix2(Updates, N_updates, Dim, "Updates");
+// #endif
 
-  // Apply first 3*n_of_3blocks updates in n_of_3blocks blocks of 3 updates with Woodbury 3x3 kernel
-  if (n_of_3blocks > 0) {
-    for (unsigned int i = 0; i < n_of_3blocks; i++) {
-      double *Updates_3block = &Updates[i * length_3block];
-      unsigned int *Updates_index_3block = &Updates_index[i * 3];
-      bool ok;
-      ok = WB3(Slater_inv, Dim, Updates_3block, Updates_index_3block);
-      if (!ok) { // Send the entire block to SM3
-#ifdef DEBUG2      
-        std::cerr << "Woodbury 3x3 kernel failed! Sending block to SM3" << std::endl;
-        showMatrix2(Updates_3block, 3, Dim, "Updates_3block");
-        showMatrix2(Updates_index_3block, 1, 3, "Updates_index_3block");
-#endif
-        SM3(Slater_inv, Dim, 3, Updates_3block, Updates_index_3block);
-      }
-    }
-  }
+//   // Apply first 3*n_of_3blocks updates in n_of_3blocks blocks of 3 updates with Woodbury 3x3 kernel
+//   if (n_of_3blocks > 0) {
+//     for (unsigned int i = 0; i < n_of_3blocks; i++) {
+//       double *Updates_3block = &Updates[i * length_3block];
+//       unsigned int *Updates_index_3block = &Updates_index[i * 3];
+//       bool ok;
+//       ok = WB3(Slater_inv, Dim, Updates_3block, Updates_index_3block);
+//       if (!ok) { // Send the entire block to SM3
+// #ifdef DEBUG2      
+//         std::cerr << "Woodbury 3x3 kernel failed! Sending block to SM3" << std::endl;
+//         showMatrix2(Updates_3block, 3, Dim, "Updates_3block");
+//         showMatrix2(Updates_index_3block, 1, 3, "Updates_index_3block");
+// #endif
+//         SM3(Slater_inv, Dim, 3, Updates_3block, Updates_index_3block);
+//       }
+//     }
+//   }
 
-  if (remainder == 2) { // Apply last remaining block of 2 updates with Woodbury 2x2 kernel
-    double *Updates_2block = &Updates[n_of_3blocks * length_3block];
-    unsigned int *Updates_index_2block = &Updates_index[3 * n_of_3blocks];
-    bool ok;
-    ok = WB2(Slater_inv, Dim, Updates_2block, Updates_index_2block);
-    if (!ok) { // Send the entire block to SM3
-      std::cerr << "Woodbury 2x2 kernel failed! Sending block to SM3" << std::endl;
-      SM3(Slater_inv, Dim, 2, Updates_2block, Updates_index_2block);
-    }
-  } else if (remainder == 1) { // Apply last remaining update with SM3
-    double *Updates_1block = &Updates[n_of_3blocks * length_3block];
-    unsigned int *Updates_index_1block = &Updates_index[3 * n_of_3blocks];
-    SM3(Slater_inv, Dim, 1, Updates_1block, Updates_index_1block);
-  } else { // remainder == 0
-    // Nothing left to do.
-  }
-}
+//   if (remainder == 2) { // Apply last remaining block of 2 updates with Woodbury 2x2 kernel
+//     double *Updates_2block = &Updates[n_of_3blocks * length_3block];
+//     unsigned int *Updates_index_2block = &Updates_index[3 * n_of_3blocks];
+//     bool ok;
+//     ok = WB2(Slater_inv, Dim, Updates_2block, Updates_index_2block);
+//     if (!ok) { // Send the entire block to SM3
+//       std::cerr << "Woodbury 2x2 kernel failed! Sending block to SM3" << std::endl;
+//       SM3(Slater_inv, Dim, 2, Updates_2block, Updates_index_2block);
+//     }
+//   } else if (remainder == 1) { // Apply last remaining update with SM3
+//     double *Updates_1block = &Updates[n_of_3blocks * length_3block];
+//     unsigned int *Updates_index_1block = &Updates_index[3 * n_of_3blocks];
+//     SM3(Slater_inv, Dim, 1, Updates_1block, Updates_index_1block);
+//   } else { // remainder == 0
+//     // Nothing left to do.
+//   }
+// }
 
-// Sherman-Morrison-Woodbury kernel 3
-// WB2, WB3, SM4 mixing scheme
-void SMWB3(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double *Updates, unsigned int *Updates_index) {
-           std::cerr << "Called Sherman-Morrison-Woodbury kernel 1 with " << N_updates << " updates" << std::endl;
+// // Sherman-Morrison-Woodbury kernel 3
+// // WB2, WB3, SM4 mixing scheme
+// void SMWB3(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double *Updates, unsigned int *Updates_index) {
+//            std::cerr << "Called Sherman-Morrison-Woodbury kernel 1 with " << N_updates << " updates" << std::endl;
 
-  unsigned int n_of_3blocks = N_updates / 3;
-  unsigned int remainder = N_updates % 3;
-  unsigned int length_3block = 3 * Dim;
-  unsigned int length_2block = 2 * Dim;
-  unsigned int length_1block = 1 * Dim;
+//   unsigned int n_of_3blocks = N_updates / 3;
+//   unsigned int remainder = N_updates % 3;
+//   unsigned int length_3block = 3 * Dim;
+//   unsigned int length_2block = 2 * Dim;
+//   unsigned int length_1block = 1 * Dim;
 
-#ifdef DEBUG2
-  showMatrix2(Updates_index, 1, N_updates, "Updates_index");
-  showMatrix2(Updates, N_updates, Dim, "Updates");
-#endif
+// #ifdef DEBUG2
+//   showMatrix2(Updates_index, 1, N_updates, "Updates_index");
+//   showMatrix2(Updates, N_updates, Dim, "Updates");
+// #endif
 
-  // Apply first 3*n_of_3blocks updates in n_of_3blocks blocks of 3 updates with Woodbury 3x3 kernel
-  if (n_of_3blocks > 0) {
-    for (unsigned int i = 0; i < n_of_3blocks; i++) {
-      double *Updates_3block = &Updates[i * length_3block];
-      unsigned int *Updates_index_3block = &Updates_index[i * 3];
-      bool ok;
-      ok = WB3(Slater_inv, Dim, Updates_3block, Updates_index_3block);
-      if (!ok) { // Send the entire block to SM4
-        std::cerr << "Woodbury 3x3 kernel failed! Sending block to SM4" << std::endl;
-#ifdef DEBUG2        
-        showMatrix2(Updates_3block, 3, Dim, "Updates_3block");
-        showMatrix2(Updates_index_3block, 1, 3, "Updates_index_3block");
-#endif
-        SM4(Slater_inv, Dim, 3, Updates_3block, Updates_index_3block);
-      }
-    }
-  }
+//   // Apply first 3*n_of_3blocks updates in n_of_3blocks blocks of 3 updates with Woodbury 3x3 kernel
+//   if (n_of_3blocks > 0) {
+//     for (unsigned int i = 0; i < n_of_3blocks; i++) {
+//       double *Updates_3block = &Updates[i * length_3block];
+//       unsigned int *Updates_index_3block = &Updates_index[i * 3];
+//       bool ok;
+//       ok = WB3(Slater_inv, Dim, Updates_3block, Updates_index_3block);
+//       if (!ok) { // Send the entire block to SM4
+//         std::cerr << "Woodbury 3x3 kernel failed! Sending block to SM4" << std::endl;
+// #ifdef DEBUG2        
+//         showMatrix2(Updates_3block, 3, Dim, "Updates_3block");
+//         showMatrix2(Updates_index_3block, 1, 3, "Updates_index_3block");
+// #endif
+//         SM4(Slater_inv, Dim, 3, Updates_3block, Updates_index_3block);
+//       }
+//     }
+//   }
 
-  if (remainder == 2) { // Apply last remaining block of 2 updates with Woodbury 2x2 kernel
-    double *Updates_2block = &Updates[n_of_3blocks * length_3block];
-    unsigned int *Updates_index_2block = &Updates_index[3 * n_of_3blocks];
-    bool ok;
-    ok = WB2(Slater_inv, Dim, Updates_2block, Updates_index_2block);
-    if (!ok) { // Send the entire block to SM4
-      std::cerr << "Woodbury 2x2 kernel failed! Sending block to SM4" << std::endl;
-      SM4(Slater_inv, Dim, 2, Updates_2block, Updates_index_2block);
-    }
-  } else if (remainder == 1) { // Apply last remaining update with SM4
-    double *Updates_1block = &Updates[n_of_3blocks * length_3block];
-    unsigned int *Updates_index_1block = &Updates_index[3 * n_of_3blocks];
-    SM4(Slater_inv, Dim, 1, Updates_1block, Updates_index_1block);
-  } else { // remainder == 0
-    // Nothing left to do.
-  }
-}
+//   if (remainder == 2) { // Apply last remaining block of 2 updates with Woodbury 2x2 kernel
+//     double *Updates_2block = &Updates[n_of_3blocks * length_3block];
+//     unsigned int *Updates_index_2block = &Updates_index[3 * n_of_3blocks];
+//     bool ok;
+//     ok = WB2(Slater_inv, Dim, Updates_2block, Updates_index_2block);
+//     if (!ok) { // Send the entire block to SM4
+//       std::cerr << "Woodbury 2x2 kernel failed! Sending block to SM4" << std::endl;
+//       SM4(Slater_inv, Dim, 2, Updates_2block, Updates_index_2block);
+//     }
+//   } else if (remainder == 1) { // Apply last remaining update with SM4
+//     double *Updates_1block = &Updates[n_of_3blocks * length_3block];
+//     unsigned int *Updates_index_1block = &Updates_index[3 * n_of_3blocks];
+//     SM4(Slater_inv, Dim, 1, Updates_1block, Updates_index_1block);
+//   } else { // remainder == 0
+//     // Nothing left to do.
+//   }
+// }
 
 // Sherman-Morrison-Woodbury kernel 4
 // WB2, SM2 mixing scheme
@@ -177,6 +192,9 @@ void SMWB4(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double 
   unsigned int length_1block = 1 * Dim;
 
   // Apply first 2*n_of_2blocks updates in n_of_2blocks blocks of 2 updates with Woodbury 2x2 kernel
+  double later_updates[Dim * N_updates];
+  unsigned int later_index[N_updates];
+  unsigned int later = 0;
   if (n_of_2blocks > 0) {
     for (unsigned int i = 0; i < n_of_2blocks; i++) {
       double *Updates_2block = &Updates[i * length_2block];
@@ -185,22 +203,29 @@ void SMWB4(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double 
       ok = WB2(Slater_inv, Dim, Updates_2block, Updates_index_2block);
       if (!ok) { // Send the entire block to SM2
         std::cerr << "Woodbury 2x2 kernel failed! Sending block to SM2" << std::endl;
-#ifdef DEBUG2
+        #ifdef DEBUG2
         showMatrix2(Updates_2block, 2, Dim, "Updates_2block");
         showMatrix2(Updates_index_2block, 1, 2, "Updates_index_2block");
-#endif
-        SM2(Slater_inv, Dim, 2, Updates_2block, Updates_index_2block);
+        #endif
+        unsigned int l = 0;
+        SM2star(Slater_inv, Dim, 2, Updates_2block, Updates_index_2block, later_updates + (Dim * later), later_index + later, &l);
+        later = later + l;
       }
     }
   }
 
-  if (remainder == 1) { // Apply last remaining update with SM4
+  if (remainder == 1) { // Apply last remaining update with SM2
     double *Updates_1block = &Updates[n_of_2blocks * length_2block];
     unsigned int *Updates_index_1block = &Updates_index[2 * n_of_2blocks];
-    SM2(Slater_inv, Dim, 1, Updates_1block, Updates_index_1block);
-  } else { // remainder == 0
-    // Nothing left to do.
+        unsigned int l = 0;
+        SM2star(Slater_inv, Dim, 1, Updates_1block, Updates_index_1block, later_updates + (Dim * later), later_index + later, &l);
+        later = later + l;
   }
+  
+  if (later > 0) {
+    SM2(Slater_inv, Dim, later, later_updates, later_index);
+  }
+
 }
 
 extern "C" {
@@ -208,14 +233,14 @@ void SMWB1_f(double **linSlater_inv, unsigned int *Dim, unsigned int *N_updates,
            double **linUpdates, unsigned int **Updates_index) {
   SMWB1(*linSlater_inv, *Dim, *N_updates, *linUpdates, *Updates_index);
 }
-void SMWB2_f(double **linSlater_inv, unsigned int *Dim, unsigned int *N_updates,
-           double **linUpdates, unsigned int **Updates_index) {
-  SMWB2(*linSlater_inv, *Dim, *N_updates, *linUpdates, *Updates_index);
-}
-void SMWB3_f(double **linSlater_inv, unsigned int *Dim, unsigned int *N_updates,
-           double **linUpdates, unsigned int **Updates_index) {
-  SMWB3(*linSlater_inv, *Dim, *N_updates, *linUpdates, *Updates_index);
-}
+// void SMWB2_f(double **linSlater_inv, unsigned int *Dim, unsigned int *N_updates,
+//            double **linUpdates, unsigned int **Updates_index) {
+//   SMWB2(*linSlater_inv, *Dim, *N_updates, *linUpdates, *Updates_index);
+// }
+// void SMWB3_f(double **linSlater_inv, unsigned int *Dim, unsigned int *N_updates,
+//            double **linUpdates, unsigned int **Updates_index) {
+//   SMWB3(*linSlater_inv, *Dim, *N_updates, *linUpdates, *Updates_index);
+// }
 void SMWB4_f(double **linSlater_inv, unsigned int *Dim, unsigned int *N_updates,
            double **linUpdates, unsigned int **Updates_index) {
   SMWB4(*linSlater_inv, *Dim, *N_updates, *linUpdates, *Updates_index);

--- a/tests/test_h5.cpp
+++ b/tests/test_h5.cpp
@@ -7,7 +7,7 @@
 #include "Woodbury.hpp"
 #include "SMWB.hpp"
 
-#define PERF
+// #define PERF
 
 #ifdef PERF
 unsigned int repetition_number;
@@ -101,10 +101,10 @@ int test_cycle(H5File file, int cycle, std::string version, double tolerance) {
       WB3(slater_inverse_nonpersistent, dim, u, col_update_index);
     } else if (version == "smwb1") {
       SMWB1(slater_inverse_nonpersistent, dim, nupdates, u, col_update_index);
-    } else if (version == "smwb2") {
-      SMWB2(slater_inverse_nonpersistent, dim, nupdates, u, col_update_index);
-    } else if (version == "smwb3") {
-      SMWB3(slater_inverse_nonpersistent, dim, nupdates, u, col_update_index);
+    // } else if (version == "smwb2") {
+    //   SMWB2(slater_inverse_nonpersistent, dim, nupdates, u, col_update_index);
+    // } else if (version == "smwb3") {
+    //   SMWB3(slater_inverse_nonpersistent, dim, nupdates, u, col_update_index);
     } else if (version == "smwb4") {
       SMWB4(slater_inverse_nonpersistent, dim, nupdates, u, col_update_index);
 #ifdef MKL
@@ -138,10 +138,10 @@ int test_cycle(H5File file, int cycle, std::string version, double tolerance) {
     WB3(slater_inverse, dim, u, col_update_index);
   } else if (version == "smwb1") {
     SMWB1(slater_inverse, dim, nupdates, u, col_update_index);
-  } else if (version == "smwb2") {
-    SMWB2(slater_inverse, dim, nupdates, u, col_update_index);
-  } else if (version == "smwb3") {
-    SMWB3(slater_inverse, dim, nupdates, u, col_update_index);
+  // } else if (version == "smwb2") {
+  //   SMWB2(slater_inverse, dim, nupdates, u, col_update_index);
+  // } else if (version == "smwb3") {
+  //   SMWB3(slater_inverse, dim, nupdates, u, col_update_index);
   } else if (version == "smwb4") {
     SMWB4(slater_inverse, dim, nupdates, u, col_update_index);
 #ifdef MKL


### PR DESCRIPTION
- Moved check on determinants in Woodbury kernels before inversion of B that was there by mistake.
- Split SM2 into SM2 and SM2star so that keeps all updates for later when used in combination with the Woodbury kernels to improve the numerical accuracy to the same level as that of SM2.