### PR TITLE
Optimize WB2 by inlining matmuls and simplifying copies

### DIFF
--- a/src/SMWB.cpp
+++ b/src/SMWB.cpp
@@ -179,7 +179,7 @@ void SMWB1(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double 
 
 // Sherman-Morrison-Woodbury kernel 4
 // WB2, SM2 mixing scheme
-void SMWB4(double *Slater_inv, unsigned int Dim, unsigned int N_updates, double *Updates, unsigned int *Updates_index) {
+void SMWB4(double *Slater_inv, const unsigned int Dim, const unsigned int N_updates, double *Updates, unsigned int *Updates_index) {
 #ifdef DEBUG2
   std::cerr << "Called Sherman-Morrison-Woodbury kernel 1 with " << N_updates << " updates" << std::endl;
   showMatrix2(Updates_index, 1, N_updates, "Updates_index");

--- a/tests/test_h5.cpp
+++ b/tests/test_h5.cpp
@@ -7,7 +7,7 @@
 #include "Woodbury.hpp"
 #include "SMWB.hpp"
 
-// #define PERF
+#define PERF
 
 #ifdef PERF
 unsigned int repetition_number;
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
   if (argc != 6) {
 #else
   if (argc != 5) {
-#endif    
+#endif
     std::cerr << "Execute from within 'datasets/'" << std::endl;
     std::cerr
         << "usage: test_h5 <version> <start cycle> <stop cycle> <tolerance>"


### PR DESCRIPTION
With LLVM.

Before:

time bin/test_h5 smwb4 50 50 1e-3 100000
# of reps. = 100000
Residual = smwb4 50 9.60426e-07 2.31848e-11
ok -- cycle 50

real	0m3,743s
user	0m3,743s
sys	0m0,000s


After:

time bin/test_h5 smwb4 50 50 1e-3 100000
# of reps. = 100000
Residual = smwb4 50 9.60423e-07 2.31847e-11
ok -- cycle 50

real	0m2,266s
user	0m2,266s
sys	0m0,001s
